### PR TITLE
Changed JSON to class variable, added new tests

### DIFF
--- a/app/src/main/java/ci/server/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ci/server/ContinuousIntegrationServer.java
@@ -82,13 +82,20 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             BufferedReader reader = request.getReader();
             webhookData = getJSON(reader);
             branch = extractBranchName(webhookData);
+            System.out.println(branch);
         } catch (IOException e) {
             e.printStackTrace();
         }
 
         response.getWriter().println("CI job done");
+        response.getWriter().println("name: " + branch);
     }
 
+    /**
+     * Creates a JSONObject from a BufferedReader
+     * @param r BufferedReader to extract the JSONObject from
+     * @return JSONObject with data from Reader, null if it fails
+     */
     public JSONObject getJSON(BufferedReader r) {
         try {
             String line = r.readLine();
@@ -99,6 +106,11 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         return null;
     }
 
+    /**
+     * Extract a branch name from JSONObject holding github webhook data
+     * @param json The JSONObject holding the data
+     * @return The name of the branch in String format
+     */
     public static String extractBranchName(JSONObject json) {
         String temp = json.getString("ref");
         return temp.split("/")[2];

--- a/app/src/main/java/ci/server/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ci/server/ContinuousIntegrationServer.java
@@ -79,13 +79,11 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         // 5. Update database
 
         try {
+            //Webhooks can have different types, ping for the first connection and then push for commit events
             String type = request.getHeader("X-GitHub-Event");
-            System.out.println("Type :" + type);
             BufferedReader reader = request.getReader();
             webhookData = getJSON(reader);
             branch = extractBranchName(webhookData, type);
-            
-            System.out.println(branch);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -112,6 +110,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
     /**
      * Extract a branch name from JSONObject holding github webhook data
      * @param json The JSONObject holding the data
+     * @param type The event type, usually "push" or "ping"
      * @return The name of the branch in String format
      */
     public static String extractBranchName(JSONObject json, String type) {
@@ -119,7 +118,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             String temp = json.getString("ref");
             return temp.split("/")[2];
         } else{
-            return "NOPE";
+            return "";
         }  
     }
 

--- a/app/src/main/java/ci/server/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ci/server/ContinuousIntegrationServer.java
@@ -47,6 +47,10 @@ public class ContinuousIntegrationServer extends AbstractHandler
 {
     //String that holds the branch name
     String branch = "";
+
+    //Object to hold the json fields from the webhook
+    JSONObject webhookData;
+
     public void handle(String target,
                        Request baseRequest,
                        HttpServletRequest request,
@@ -69,8 +73,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
         
         try{
             BufferedReader reader = request.getReader();
-            String line = reader.readLine();
-            branch = extractBranchName(line);
+            webhookData = getJSON(reader);
+            branch = extractBranchName(webhookData);
         } catch (Exception e){
             e.printStackTrace();
         }
@@ -78,10 +82,13 @@ public class ContinuousIntegrationServer extends AbstractHandler
         response.getWriter().println("CI job done");
     }
 
-    public static String extractBranchName(String input){
-        //Object to hold the json fields from the webhook
-        JSONObject jsonObject = new JSONObject(input);
-        String temp = jsonObject.getString("ref");
+    public JSONObject getJSON(BufferedReader r){
+        String line = r.readLine();
+        return new JSONObject(line);
+    }
+
+    public static String extractBranchName(JSONObject json){
+        String temp = json.getString("ref");
         return temp.split("/")[2];
     }
 

--- a/app/src/main/java/ci/server/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ci/server/ContinuousIntegrationServer.java
@@ -12,51 +12,58 @@ import java.io.BufferedReader;
 import java.io.IOException;
 
 import org.json.*;
-/** 
- Skeleton of a ContinuousIntegrationServer which acts as webhook
- See the Jetty documentation for API documentation of those classes.
 
-FEATURES:
-
-core CI feature #1 - compilation: the CI server supports compiling the group project, 
-a static syntax check is to be performed for languages without compiler. Compilation is 
-triggered as webhook, the CI server compiles the branch where the change has been made, 
-as specified in the HTTP payload.
-
-core CI feature #2 - testing: the CI server supports executing the automated tests of 
-the group project. Testing is triggered as webhook, on the branch where the change has 
-been made, as specified in the HTTP payload.
-
-core CI feature #3 - notification): the CI server supports notification of CI results. 
-At least one notification mechanism of the following list is implemented:
-
-    Commit status: the CI server sets the commit status 
-
-    Email: the CI server sends an email to the project member about the build result.
-
-
-Technical documentation:
-
- 1- Run the CI server on ngrok and add the webhook on github
- 2- Try to commit/push to github repo
- 3- The CI server receives the webhook notifications and then launch the automated build
- 4- Notifiy the results
- 
-*/
-public class ContinuousIntegrationServer extends AbstractHandler
-{
-    //String that holds the branch name
+/**
+ * Skeleton of a ContinuousIntegrationServer which acts as webhook
+ * See the Jetty documentation for API documentation of those classes.
+ * 
+ * FEATURES:
+ * 
+ * core CI feature #1 - compilation: the CI server supports compiling the group
+ * project,
+ * a static syntax check is to be performed for languages without compiler.
+ * Compilation is
+ * triggered as webhook, the CI server compiles the branch where the change has
+ * been made,
+ * as specified in the HTTP payload.
+ * 
+ * core CI feature #2 - testing: the CI server supports executing the automated
+ * tests of
+ * the group project. Testing is triggered as webhook, on the branch where the
+ * change has
+ * been made, as specified in the HTTP payload.
+ * 
+ * core CI feature #3 - notification): the CI server supports notification of CI
+ * results.
+ * At least one notification mechanism of the following list is implemented:
+ * 
+ * Commit status: the CI server sets the commit status
+ * 
+ * Email: the CI server sends an email to the project member about the build
+ * result.
+ * 
+ * 
+ * Technical documentation:
+ * 
+ * 1- Run the CI server on ngrok and add the webhook on github
+ * 2- Try to commit/push to github repo
+ * 3- The CI server receives the webhook notifications and then launch the
+ * automated build
+ * 4- Notifiy the results
+ * 
+ */
+public class ContinuousIntegrationServer extends AbstractHandler {
+    // String that holds the branch name
     String branch = "";
 
-    //Object to hold the json fields from the webhook
+    // Object to hold the json fields from the webhook
     JSONObject webhookData;
 
     public void handle(String target,
-                       Request baseRequest,
-                       HttpServletRequest request,
-                       HttpServletResponse response) 
-        throws IOException, ServletException
-    {
+            Request baseRequest,
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws IOException, ServletException {
         response.setContentType("text/html;charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         baseRequest.setHandled(true);
@@ -64,39 +71,43 @@ public class ContinuousIntegrationServer extends AbstractHandler
         System.out.println(target);
 
         // here you do all the continuous integration tasks
-        //   
+        //
         // 1. Clone repo
         // 2. Find build config file in root directory
         // 3. Parse and run commands
         // 4. Notify github of result
         // 5. Update database
-        
-        try{
+
+        try {
             BufferedReader reader = request.getReader();
             webhookData = getJSON(reader);
             branch = extractBranchName(webhookData);
-        } catch (Exception e){
+        } catch (IOException e) {
             e.printStackTrace();
         }
 
         response.getWriter().println("CI job done");
     }
 
-    public JSONObject getJSON(BufferedReader r){
-        String line = r.readLine();
-        return new JSONObject(line);
+    public JSONObject getJSON(BufferedReader r) {
+        try {
+            String line = r.readLine();
+            return new JSONObject(line);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
-    public static String extractBranchName(JSONObject json){
+    public static String extractBranchName(JSONObject json) {
         String temp = json.getString("ref");
         return temp.split("/")[2];
     }
 
     // used to start the CI server in command line
-    public static void startServer() throws Exception
-    {
+    public static void startServer() throws Exception {
         Server server = new Server(8080);
-        server.setHandler(new ContinuousIntegrationServer()); 
+        server.setHandler(new ContinuousIntegrationServer());
         server.start();
         server.join();
     }

--- a/app/src/main/java/ci/server/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ci/server/ContinuousIntegrationServer.java
@@ -79,9 +79,12 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         // 5. Update database
 
         try {
+            String type = request.getHeader("X-GitHub-Event");
+            System.out.println("Type :" + type);
             BufferedReader reader = request.getReader();
             webhookData = getJSON(reader);
-            branch = extractBranchName(webhookData);
+            branch = extractBranchName(webhookData, type);
+            
             System.out.println(branch);
         } catch (IOException e) {
             e.printStackTrace();
@@ -111,9 +114,13 @@ public class ContinuousIntegrationServer extends AbstractHandler {
      * @param json The JSONObject holding the data
      * @return The name of the branch in String format
      */
-    public static String extractBranchName(JSONObject json) {
-        String temp = json.getString("ref");
-        return temp.split("/")[2];
+    public static String extractBranchName(JSONObject json, String type) {
+        if(type.equals("push")){
+            String temp = json.getString("ref");
+            return temp.split("/")[2];
+        } else{
+            return "NOPE";
+        }  
     }
 
     // used to start the CI server in command line

--- a/app/src/test/java/ci/server/ContinuousIntegrationServerTest.java
+++ b/app/src/test/java/ci/server/ContinuousIntegrationServerTest.java
@@ -7,6 +7,7 @@ import org.checkerframework.checker.units.qual.C;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -29,6 +30,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.json.*;
 
 public class ContinuousIntegrationServerTest {
+    @Test void jsonNotNullTest(){
+        BufferedReader read;
+        JSONObject json = null;
+        try{
+          //  payload = new String(Files.readAllBytes(Paths.get("examplePayload.json")));
+            read = new BufferedReader(new FileReader("examplePayload.json"));
+            json = new JSONObject(read);
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        assertNotNull(json);
+    }
+
     @Test void branchNameTest(){
         String payload = "";
         JSONObject json = null;

--- a/app/src/test/java/ci/server/ContinuousIntegrationServerTest.java
+++ b/app/src/test/java/ci/server/ContinuousIntegrationServerTest.java
@@ -53,8 +53,21 @@ public class ContinuousIntegrationServerTest {
         } catch(Exception e) {
             e.printStackTrace();
         }
-        System.out.println(ContinuousIntegrationServer.extractBranchName(json));
-        assertThat(ContinuousIntegrationServer.extractBranchName(json), equalTo("readbranch"));
+
+        assertThat(ContinuousIntegrationServer.extractBranchName(json,"push"), equalTo("readbranch"));
+    }
+
+    @Test void branchNamePingEventTest(){
+        String payload = "";
+        JSONObject json = null;
+        try{
+            payload = new String(Files.readAllBytes(Paths.get("examplePayload.json")));
+            json = new JSONObject(payload);
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        assertThat(ContinuousIntegrationServer.extractBranchName(json,"ping"), equalTo(""));
     }
 
 }

--- a/app/src/test/java/ci/server/ContinuousIntegrationServerTest.java
+++ b/app/src/test/java/ci/server/ContinuousIntegrationServerTest.java
@@ -26,16 +26,20 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.json.*;
+
 public class ContinuousIntegrationServerTest {
     @Test void branchNameTest(){
         String payload = "";
+        JSONObject json = null;
         try{
             payload = new String(Files.readAllBytes(Paths.get("examplePayload.json")));
+            json = new JSONObject(payload);
         } catch(Exception e) {
             e.printStackTrace();
         }
-
-        assertThat(ContinuousIntegrationServer.extractBranchName(payload), equalTo("readbranch"));
+        System.out.println(ContinuousIntegrationServer.extractBranchName(json));
+        assertThat(ContinuousIntegrationServer.extractBranchName(json), equalTo("readbranch"));
     }
 
 }


### PR DESCRIPTION
Fixes #17

Changed a bit how the JSON object is set and updated the other methods for ContinuousIntegrationServer to adhere to the new standard. Also updated the previous test and added two new tests to check the functionality. Also added a new check in extractBranchName to see if the JSON came from a push event, as there was previously an error message if it was attempted to be extracted from the ping event that occurs when the webhook is first set up.