### PR TITLE
Added java version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To only run the tests, one can run the command:
 gradle test
 ```
 
-This requires the system to have gradle version 7.2 or higher installed.
+This requires the system to have **gradle version 7.2** or higher installed. Additionally, the project requires **Java 11** or newer. 
 
 ### Credits
 


### PR DESCRIPTION
Fixes #28

As java 11 is needed for the HTTP methods in the Notify class. If there's some other issue with using Java 11 then I guess we'll have to change it.